### PR TITLE
leads.js missing CLEAR_LEADS action

### DIFF
--- a/leadmanager/frontend/src/reducers/leads.js
+++ b/leadmanager/frontend/src/reducers/leads.js
@@ -1,4 +1,4 @@
-import { GET_LEADS, DELETE_LEAD, ADD_LEAD } from "../actions/types.js";
+import { GET_LEADS, DELETE_LEAD, ADD_LEAD, CLEAR_LEADS } from "../actions/types.js";
 
 const initialState = {
   leads: []


### PR DESCRIPTION
noticed this was missing when I attempted to do a fresh install