### PR TITLE
Workaround to account for breaking changes to django-rest-knox 4.0 (jan-19)

### DIFF
--- a/leadmanager/accounts/api.py
+++ b/leadmanager/accounts/api.py
@@ -11,9 +11,10 @@ class RegisterAPI(generics.GenericAPIView):
     serializer = self.get_serializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     user = serializer.save()
+    _, token = AuthToken.objects.create(user)
     return Response({
       "user": UserSerializer(user, context=self.get_serializer_context()).data,
-      "token": AuthToken.objects.create(user)
+      "token": token
     })
 
 # Login API
@@ -24,9 +25,10 @@ class LoginAPI(generics.GenericAPIView):
     serializer = self.get_serializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     user = serializer.validated_data
+    _, token = AuthToken.objects.create(user)
     return Response({
       "user": UserSerializer(user, context=self.get_serializer_context()).data,
-      "token": AuthToken.objects.create(user)
+      "token": token
     })
 
 # Get User API


### PR DESCRIPTION
Breaking changes to Django-Rest-Knox in v 4.0.0. 

`knox.models.AuthToken.objects.create()` now returns a tuple of the model instance and the token itself instead of just the token. A workaround has been made to address this.

From Django-Rest-Knox changelog:
> 4.0.0
> =====
> 
> **BREAKING** This is a major release version because it
> breaks the existing API.
> 
> Changes have been made to the `create()` method on the `AuthToken` model. 
> It now returns the model instance and the raw `token` instead
> of just the `token` to allow the `expiry` field to be included in the
> success response.