### PR TITLE
The Token.objects.create returns a tuple (instance, token)

### DIFF
--- a/leadmanager/accounts/api.py
+++ b/leadmanager/accounts/api.py
@@ -26,7 +26,7 @@ class LoginAPI(generics.GenericAPIView):
     user = serializer.validated_data
     return Response({
       "user": UserSerializer(user, context=self.get_serializer_context()).data,
-      "token": AuthToken.objects.create(user)
+      "token": AuthToken.objects.create(user)[1]
     })
 
 # Get User API


### PR DESCRIPTION
in order to get the token use [1] because The Token.objects.create returns a tuple (instance, token)

source: https://stackoverflow.com/questions/55668375/object-of-type-authtoken-is-not-json-serializable