### PR TITLE
react-alerts api changed => need to change the call to withAlert()

### DIFF
--- a/leadmanager/frontend/src/components/layout/Alerts.js
+++ b/leadmanager/frontend/src/components/layout/Alerts.js
@@ -1,7 +1,7 @@
-import React, { Component, Fragment } from 'react';
-import { withAlert } from 'react-alert';
-import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
+import React, { Component, Fragment } from "react";
+import { withAlert } from "react-alert";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
 
 export class Alerts extends Component {
   static propTypes = {

--- a/leadmanager/frontend/src/components/layout/Alerts.js
+++ b/leadmanager/frontend/src/components/layout/Alerts.js
@@ -1,7 +1,7 @@
-import React, { Component, Fragment } from "react";
-import { withAlert } from "react-alert";
-import { connect } from "react-redux";
-import PropTypes from "prop-types";
+import React, { Component, Fragment } from 'react';
+import { withAlert } from 'react-alert';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 
 export class Alerts extends Component {
   static propTypes = {
@@ -38,4 +38,4 @@ const mapStateToProps = state => ({
   message: state.messages
 });
 
-export default connect(mapStateToProps)(withAlert(Alerts));
+export default connect(mapStateToProps)(withAlert()(Alerts));


### PR DESCRIPTION
Api for react-alerts has changed, so `withAlert(<ComponentName>)` now needs to be called `withAlert()(<ComponentName>)`. See stackoverflow link below where the issue has already been raised.

[https://stackoverflow.com/questions/58785252/why-does-exporting-withalertalerts-causes-error-but-withalertalerts-works](url)