### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "webpack --mode development --watch ./leadmanager/frontend/src/index.js --output ./leadmanager/frontend/static/frontend/main.js",
-    "build": "webpack --mode production ./leadmanager/frontend/src/index.js --output ./leadmanager/frontend/static/frontend/main.js"
+    "dev": "webpack --mode development --watch --entry ./leadmanager/frontend/src/index.js --output-path ./leadmanager/frontend/static/frontend/main.js",
+    "build": "webpack --mode production --entry ./leadmanager/frontend/src/index.js --output-path ./leadmanager/frontend/static/frontend/main.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "webpack --mode development --watch --entry ./leadmanager/frontend/src/index.js --output-path ./leadmanager/frontend/static/frontend/main.js",
-    "build": "webpack --mode production --entry ./leadmanager/frontend/src/index.js --output-path ./leadmanager/frontend/static/frontend/main.js"
+    "dev": "webpack --mode development --watch --entry ./leadmanager/frontend/src/index.js --output-path ./leadmanager/frontend/static/frontend/",
+    "build": "webpack --mode production --entry ./leadmanager/frontend/src/index.js --output-path ./leadmanager/frontend/static/frontend/"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
changed build and dev scripts to use the --entry and --output-path flags as defined in the webpack-cli docs
 This allows these scripts to work on newer versions of webpack-cli