### PR TITLE
Skip importing react on components and use webpack.config.js entry/output rules in package.json scripts

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "presets": [
+    "@babel/preset-env",
+    ["@babel/preset-react", {"runtime": "automatic"}]
+],
   "plugins": ["transform-class-properties"]
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "webpack --mode development --watch ./leadmanager/frontend/src/index.js --output ./leadmanager/frontend/static/frontend/main.js",
-    "build": "webpack --mode production ./leadmanager/frontend/src/index.js --output ./leadmanager/frontend/static/frontend/main.js"
+    "dev": "webpack --config webpack.config.js --mode=development --watch",
+    "build": "webpack --config webpack.config.js --mode=production"
   },
   "keywords": [],
   "author": "",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,11 @@
+var path = require("path")
+
 module.exports = {
+  entry: path.join(__dirname, "leadmanager/frontend/src/index"),
+  output: {
+    path: path.join(__dirname, "leadmanager/frontend/static/frontend"),
+    filename: "[name].js",
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
- Update .babelrc to skip importing react on every components